### PR TITLE
refactor: standardize singleton naming and remove intermediate path vars (#21)

### DIFF
--- a/src/A_encik/data/storage.py
+++ b/src/A_encik/data/storage.py
@@ -7,7 +7,7 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
-from A.core.paths import data_dir as _data_dir, ensure_dirs as _ensure_dirs
+from A.core.paths import data_dir, ensure_dirs as _ensure_dirs
 from A.core.backup_targets import BackupTarget
 from A.data.base import (
     SQLiteDB,
@@ -18,9 +18,6 @@ from A.data.base import (
 )
 from A.data.search import FTSConfig
 from A.utils.normalize import fold_search_text
-
-_DATA_DIR: Path = _data_dir()
-_DB_FILE: Path = _DATA_DIR / "encik.db"
 
 _CREATE_ENCIK = """
 CREATE TABLE IF NOT EXISTS encik (
@@ -67,16 +64,17 @@ def _repair_if_corrupted() -> bool:
     Returns:
         True if repair was attempted, False if nothing was needed.
     """
-    if _health_check(_DB_FILE):
+    _path = data_dir() / "encik.db"
+    if _health_check(_path):
         return False
 
     # Core repair: delete WAL/SHM, VACUUM
-    if _core_repair(_DB_FILE):
+    if _core_repair(_path):
         return True
 
     # Still broken — drop and recreate semantika_cache
     try:
-        _conn = sqlite3.connect(str(_DB_FILE))
+        _conn = sqlite3.connect(str(_path))
         _conn.execute("DROP TABLE IF EXISTS semantika_cache")
         _conn.execute(
             """CREATE TABLE IF NOT EXISTS semantika_cache (
@@ -110,14 +108,15 @@ def repair_db() -> bool:
 
 
 def _backup_db() -> None:
-    backup_db(_DB_FILE)
+    backup_db(data_dir() / "encik.db")
 
 
 def _readonly_recover() -> SQLiteDB | None:
     import tempfile
+    _path = data_dir() / "encik.db"
     tmp = Path(tempfile.mktemp(suffix=".db"))
     try:
-        count = _core_readonly_recover(_DB_FILE, tmp)
+        count = _core_readonly_recover(_path, tmp)
     except Exception:
         tmp.unlink(missing_ok=True)
         return None
@@ -130,32 +129,37 @@ def _readonly_recover() -> SQLiteDB | None:
         "Recovered {n} entries...",
         "Récupéré {n} entrées...",
     ).format(n=count))
-    _bak = _DB_FILE.with_suffix(".db.dead")
+    _bak = _path.with_suffix(".db.dead")
     import shutil as _su
-    _su.move(str(_DB_FILE), str(_bak))
-    _su.move(str(tmp), str(_DB_FILE))
+    _su.move(str(_path), str(_bak))
+    _su.move(str(tmp), str(_path))
     for _sfx in ("-wal", "-shm"):
-        (_DB_FILE.parent / (_DB_FILE.name + _sfx)).unlink(missing_ok=True)
+        (_path.parent / (_path.name + _sfx)).unlink(missing_ok=True)
     _info(_tr(
         "Reakiris {n} enskribojn (malnova DB: {bak})",
         "Recovered {n} entries (old DB: {bak})",
         "Récupéré {n} entrées (ancienne DB: {bak})",
     ).format(n=count, bak=_bak.name))
-    return SQLiteDB(_DB_FILE)
+    return SQLiteDB(_path)
 
 
 _db_instance: SQLiteDB | None = None
 _repair_checked: bool = False  # Only check corruption once per process
 
 
-def get_db() -> SQLiteDB:
+def get_db(path: Path | None = None) -> SQLiteDB:
     """Get or create the shared database connection (singleton).
 
     All callers within the same process share one ``SQLiteDB`` instance,
     which uses one cached SQLite connection. This avoids WAL/SHM conflicts
     that occur when multiple connections access the same database file.
+
+    Args:
+        path: Optional explicit database path. If omitted, defaults to
+            ``data_dir() / "encik.db"`` (respects ``A_DIR`` env var).
     """
     global _db_instance, _repair_checked
+    db_path = path or data_dir() / "encik.db"
 
     # Fast path: existing healthy instance (repair checked on first access)
     if _db_instance is not None and _repair_checked:
@@ -175,7 +179,7 @@ def get_db() -> SQLiteDB:
     if _db_instance is None:
         # Backup before any DDL
         _backup_db()
-        _db_instance = SQLiteDB(_DB_FILE)
+        _db_instance = SQLiteDB(db_path)
 
     # Initialize schema and run migrations.
     # If the DB is corrupted these may fail — catch and surface a clear message.
@@ -193,9 +197,9 @@ def get_db() -> SQLiteDB:
                 _actual = {c for c in ENCIK_FTS_CONFIG.fts_columns if c in _fts_sql}
                 if _actual != _expected:
                     _db_instance.close()
-                    _db_instance = SQLiteDB(_DB_FILE)
+                    _db_instance = SQLiteDB(db_path)
         except Exception:
-            _db_instance = SQLiteDB(_DB_FILE)
+            _db_instance = SQLiteDB(db_path)
 
         _db_instance.execute(_CREATE_ENCIK)
         for stmt in _CREATE_ENCIK_INDEXES.strip().split(";"):
@@ -397,7 +401,7 @@ def get_backup_targets() -> list[BackupTarget]:
     """Return backup targets for A-encik."""
     return [
         BackupTarget(
-            path=_DB_FILE,
+            path=data_dir() / "encik.db",
             category="data",
             module="encik",
             label="Encik database",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from A.core.testing import patch_paths
 
 
 @pytest.fixture(autouse=True)
 def isolate_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Isolate all tests to a tmp_path database to prevent test data leakage."""
+    """Isolate all tests to a tmp_path database to prevent test data leakage.
+
+    Redirects ``data_dir()`` via ``A_DIR`` env var and resets the DB
+    singleton so the next ``get_db()`` call recomputes the path.
+    """
     import A_encik.data.storage as storage_module
 
-    monkeypatch.setattr(storage_module, "_DATA_DIR", tmp_path)
-    monkeypatch.setattr(storage_module, "_DB_FILE", tmp_path / "encik.db")
+    patch_paths(monkeypatch, tmp_path)
     storage_module._db_instance = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,14 +13,6 @@ from typer.testing import CliRunner
 from A_encik.cli import app
 
 
-@pytest.fixture(autouse=True)
-def isolate_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Isolate database to tmp_path to prevent leaking test data."""
-    import A_encik.data.storage as storage_module
-    monkeypatch.setattr(storage_module, "_DATA_DIR", tmp_path)
-    monkeypatch.setattr(storage_module, "_DB_FILE", tmp_path / "encik.db")
-
-
 @pytest.fixture
 def runner():
     """Create CLI test runner."""

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -181,15 +181,13 @@ class TestEncikServiceIntegration:
         from A_encik.service import EncikService
         
         # Patch to use temp directory
-        with patch.object(storage_module, "_DATA_DIR", tmp_path):
-            with patch.object(storage_module, "_DB_FILE", tmp_path / "encik.db"):
-                with patch.object(storage_module, "_ensure_dirs", lambda: None):
-                    with patch("A.core.paths.data_dir", return_value=tmp_path):
-                        with patch("A.data.base.data_dir", return_value=tmp_path):
-                            # Use get_db() which initializes schema
-                            db = storage_module.get_db()
-                            service = EncikService(db)
-                            yield service
+        with patch.object(storage_module, "_ensure_dirs", lambda: None):
+            with patch.object(storage_module, "data_dir", return_value=tmp_path):
+                with patch("A.data.base.data_dir", return_value=tmp_path):
+                    # Use get_db() which initializes schema
+                    db = storage_module.get_db()
+                    service = EncikService(db)
+                    yield service
     
     def test_create_entry(self, service):
         """Test creating an entry."""
@@ -338,17 +336,15 @@ class TestBidirectionalLinks:
         from A_encik.service import EncikService
         from unittest.mock import patch
 
-        with patch.object(storage_module, "_DATA_DIR", tmp_path):
-            with patch.object(storage_module, "_DB_FILE", tmp_path / "encik.db"):
-                with patch.object(storage_module, "_ensure_dirs", lambda: None):
-                    with patch("A.core.paths.data_dir", return_value=tmp_path):
-                        with patch("A.data.base.data_dir", return_value=tmp_path):
-                            from A_encik.data.storage import get_db
-                            db = get_db()
-                            # Reset singleton
-                            import A_encik.service as svc_module
-                            svc_module._encik_service = None
-                            yield EncikService(db)
+        with patch.object(storage_module, "_ensure_dirs", lambda: None):
+            with patch.object(storage_module, "data_dir", return_value=tmp_path):
+                with patch("A.data.base.data_dir", return_value=tmp_path):
+                    from A_encik.data.storage import get_db
+                    db = get_db()
+                    # Reset singleton
+                    import A_encik.service as svc_module
+                    svc_module._encik_service = None
+                    yield EncikService(db)
 
     def test_reverse_link_added_on_update(self, service):
         """Test adding a ligilo entry creates a reverse link in the target."""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from A.core.testing import patch_paths
 
 from A_encik.data.storage import (
     get_db,
@@ -28,13 +29,11 @@ def temp_db_path(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def mock_data_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Mock data directory to temp path."""
-    # Import and patch after establishing the path module
+    """Redirect data directory to temp path via A_DIR."""
     import A_encik.data.storage as storage_module
-    
-    # Patch at module level
-    monkeypatch.setattr(storage_module, "_DATA_DIR", tmp_path)
-    monkeypatch.setattr(storage_module, "_DB_FILE", tmp_path / "encik.db")
+
+    patch_paths(monkeypatch, tmp_path)
+    storage_module._db_instance = None
 
 
 class TestRowToDict:
@@ -152,12 +151,11 @@ class TestEnsureDirs:
     def test_ensure_dirs_creates_directory(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Test that ensure_dirs creates the data directory."""
         import A_encik.data.storage as storage_module
-        
-        # Patch module globals
-        monkeypatch.setattr(storage_module, "_DATA_DIR", tmp_path)
-        monkeypatch.setattr(storage_module, "_ensure_dirs", lambda: None)
-        
-        # Should not raise - just call ensure_dirs
+
+        patch_paths(monkeypatch, tmp_path)
+        storage_module._db_instance = None
+
+        # ensure_dirs should create the redirected data dir
         storage_module.ensure_dirs()
 
 
@@ -167,28 +165,15 @@ class TestGetDb:
     def test_get_db_creates_tables(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Test that get_db creates required tables."""
         import A_encik.data.storage as storage_module
-        
-        # Patch module globals
-        monkeypatch.setattr(storage_module, "_DATA_DIR", tmp_path)
-        monkeypatch.setattr(storage_module, "_DB_FILE", tmp_path / "encik.db")
-        monkeypatch.setattr(storage_module, "_ensure_dirs", lambda: None)
-        
-        # Import after patching
-        from A.data.base import SQLiteDB
+
+        patch_paths(monkeypatch, tmp_path)
+        storage_module._db_instance = None
+
         from A.core.paths import data_dir
-        
-        # Patch data_dir globally for SQLiteDB
-        monkeypatch.setattr(
-            "A.core.paths.data_dir", 
-            lambda: tmp_path
-        )
-        monkeypatch.setattr(
-            "A.data.base.data_dir",
-            lambda: tmp_path
-        )
-        
-        # Now get_db should work
-        # Note: This will need proper A-core mocking in integration
+        monkeypatch.setattr("A.data.base.data_dir", lambda: tmp_path)
+
+        # Should not raise
+        db = storage_module.get_db()
 
 
 class TestBackupDb:
@@ -198,9 +183,12 @@ class TestBackupDb:
         """_backup_db() creates encik.db.bak when encik.db exists."""
         import A_encik.data.storage as storage_module
 
+        monkeypatch.setattr(storage_module, "data_dir", lambda: tmp_path)
+        monkeypatch.setattr("A.data.base.data_dir", lambda: tmp_path)
+        storage_module._db_instance = None
+
         db_path = tmp_path / "encik.db"
         db_path.write_text("fake sqlite content")
-        monkeypatch.setattr(storage_module, "_DB_FILE", db_path)
 
         storage_module._backup_db()
 
@@ -212,10 +200,10 @@ class TestBackupDb:
         """_backup_db() silently does nothing when no DB file exists."""
         import A_encik.data.storage as storage_module
 
-        db_path = tmp_path / "encik.db"
-        monkeypatch.setattr(storage_module, "_DB_FILE", db_path)
+        monkeypatch.setattr(storage_module, "data_dir", lambda: tmp_path)
+        monkeypatch.setattr("A.data.base.data_dir", lambda: tmp_path)
+        storage_module._db_instance = None
 
-        # Should not raise
         storage_module._backup_db()
         bak_path = tmp_path / "encik.db.bak"
         assert not bak_path.exists()
@@ -224,11 +212,14 @@ class TestBackupDb:
         """_backup_db() overwrites previous .bak file."""
         import A_encik.data.storage as storage_module
 
+        monkeypatch.setattr(storage_module, "data_dir", lambda: tmp_path)
+        monkeypatch.setattr("A.data.base.data_dir", lambda: tmp_path)
+        storage_module._db_instance = None
+
         db_path = tmp_path / "encik.db"
         db_path.write_text("new content")
         old_bak = tmp_path / "encik.db.bak"
         old_bak.write_text("old content")
-        monkeypatch.setattr(storage_module, "_DB_FILE", db_path)
 
         storage_module._backup_db()
         assert old_bak.read_text() == "new content"
@@ -241,11 +232,9 @@ class TestRepairChecked:
         """_repair_checked is True after first get_db() call."""
         import A_encik.data.storage as storage_module
 
-        monkeypatch.setattr(storage_module, "_DATA_DIR", tmp_path)
-        monkeypatch.setattr(storage_module, "_DB_FILE", tmp_path / "encik.db")
-        monkeypatch.setattr(storage_module, "_ensure_dirs", lambda: None)
-        monkeypatch.setattr("A.core.paths.data_dir", lambda: tmp_path)
+        patch_paths(monkeypatch, tmp_path)
         monkeypatch.setattr("A.data.base.data_dir", lambda: tmp_path)
+        storage_module._db_instance = None
         monkeypatch.setattr(storage_module, "_repair_checked", False)
 
         db = storage_module.get_db()
@@ -255,11 +244,9 @@ class TestRepairChecked:
         """Second get_db() call returns same instance without re-checking."""
         import A_encik.data.storage as storage_module
 
-        monkeypatch.setattr(storage_module, "_DATA_DIR", tmp_path)
-        monkeypatch.setattr(storage_module, "_DB_FILE", tmp_path / "encik.db")
-        monkeypatch.setattr(storage_module, "_ensure_dirs", lambda: None)
-        monkeypatch.setattr("A.core.paths.data_dir", lambda: tmp_path)
+        patch_paths(monkeypatch, tmp_path)
         monkeypatch.setattr("A.data.base.data_dir", lambda: tmp_path)
+        storage_module._db_instance = None
         monkeypatch.setattr(storage_module, "_repair_checked", False)
 
         call_count = [0]
@@ -273,8 +260,8 @@ class TestRepairChecked:
         first_count = call_count[0]
         db2 = storage_module.get_db()
 
-        assert db1 is db2  # Same cached instance
-        assert call_count[0] == first_count  # Repair not called again
+        assert db1 is db2
+        assert call_count[0] == first_count
 
 
 class TestReadonlyRecover:
@@ -284,16 +271,17 @@ class TestReadonlyRecover:
         """_readonly_recover returns a valid DB instance when encik table has entries."""
         import A_encik.data.storage as storage_module
 
-        # Create a valid DB
+        monkeypatch.setattr(storage_module, "data_dir", lambda: tmp_path)
+        monkeypatch.setattr("A.data.base.data_dir", lambda: tmp_path)
+        storage_module._db_instance = None
+
         db = sqlite3.connect(str(tmp_path / "encik.db"))
         db.execute("CREATE TABLE encik (uuid TEXT PRIMARY KEY, terminologio TEXT)")
         db.execute("INSERT INTO encik (uuid, terminologio) VALUES ('aaaaaaaa-1111-2222-3333-444444444444', '{\"eo\":\"test\"}')")
         db.commit()
         db.close()
 
-        monkeypatch.setattr(storage_module, "_DB_FILE", tmp_path / "encik.db")
         result = storage_module._readonly_recover()
-        # Should return a new SQLiteDB with the entry recovered
         assert result is not None
         rows = result.execute("SELECT COUNT(*) AS c FROM encik")
         assert rows[0]["c"] == 1
@@ -301,6 +289,10 @@ class TestReadonlyRecover:
     def test_recover_recovers_readable_entries(self, tmp_path, monkeypatch):
         """_readonly_recover extracts entries from corrupted DB into a clean one."""
         import A_encik.data.storage as storage_module
+
+        monkeypatch.setattr(storage_module, "data_dir", lambda: tmp_path)
+        monkeypatch.setattr("A.data.base.data_dir", lambda: tmp_path)
+        storage_module._db_instance = None
 
         db = sqlite3.connect(str(tmp_path / "encik.db"), timeout=30)
         db.execute("CREATE TABLE encik (uuid TEXT PRIMARY KEY, terminologio TEXT)")
@@ -310,9 +302,7 @@ class TestReadonlyRecover:
         db.commit()
         db.close()
 
-        monkeypatch.setattr(storage_module, "_DB_FILE", tmp_path / "encik.db")
         result = storage_module._readonly_recover()
-
         if result is not None:
             rows = result.execute("SELECT COUNT(*) AS c FROM encik")
             assert rows[0]["c"] == 2
@@ -321,11 +311,13 @@ class TestReadonlyRecover:
         """_readonly_recover returns None when even read-only access fails."""
         import A_encik.data.storage as storage_module
 
+        monkeypatch.setattr(storage_module, "data_dir", lambda: tmp_path)
+        monkeypatch.setattr("A.data.base.data_dir", lambda: tmp_path)
+        storage_module._db_instance = None
+
         db_path = tmp_path / "encik.db"
-        # Write garbage (not a SQLite DB at all)
         db_path.write_bytes(b'\x00' * 512)
 
-        monkeypatch.setattr(storage_module, "_DB_FILE", db_path)
         result = storage_module._readonly_recover()
         assert result is None
 


### PR DESCRIPTION
### Summary

Implements the 5-phase plan from issue #21:

**Phase 1a** — A-semantika: renamed `_DB` → `_db_instance` in `storage.py` + test files
**Phase 1b** — A-agento: renamed `_db` → `_db_instance` in `_storage_base.py`
**Phase 2** — A-encik, A-vorto, A-organizi, A-medio: removed `_DATA_DIR`/`_DB_FILE` intermediate variables, inlined `data_dir()` calls
**Phase 3** — A-core: added `simulate()` context manager to `A.core.testing` with safety guard

### Testing

- ✅ All existing tests pass (450 A-core, 136 A-encik, 125 A-vorto, 307 A-organizi, 155 A-medio, 155 A-agento, 670 A-semantika)
- ✅ User-simulation smoke tests: 10/11 CLI commands work with `A_DIR` isolation (1 pre-existing: A-organizi has no top-level `ls`)
- ✅ `simulate()` context manager verified: sets `A_DIR`, validates isolation, restores on exit