### PR TITLE
fix: localize option flags to Esperanto

### DIFF
--- a/src/A_encik/_cli_aldoni.py
+++ b/src/A_encik/_cli_aldoni.py
@@ -106,7 +106,7 @@ def register_commands(app: typer.Typer) -> None:
         ),
         bce: bool = typer.Option(
             False,
-            "--bce",
+            "--antau-kristo",
             help=tr_multi(
                 "Antaŭ Kristo (a.K.E.)",
                 "BCE / Before Common Era",

--- a/src/A_encik/_cli_crud.py
+++ b/src/A_encik/_cli_crud.py
@@ -123,7 +123,7 @@ def register_commands(app: typer.Typer) -> None:
         open_browser: bool = typer.Option(
             False,
             "-o",
-            "--open",
+            "--malfermi",
             help=tr_multi("Malfermi en retumilo", "Open in browser", "Ouvrir dans le navigateur"),
         ),
         kopii: bool = typer.Option(
@@ -442,7 +442,7 @@ def register_commands(app: typer.Typer) -> None:
         )],
         hard: bool = typer.Option(
             False,
-            "--hard",
+            "--permanenta",
             "-H",
             help=tr_multi("Forigi permanente (preterrubujo)", "Permanent delete (no trash)", "Suppression définitive (pas de corbeille)"),
         ),

--- a/src/A_encik/_cli_semantika.py
+++ b/src/A_encik/_cli_semantika.py
@@ -317,7 +317,7 @@ def semantika_ligilo_modifi(
         None, "-a", "--aliazoj", help=tr_multi("Novaj aliasoj (CSV)", "New aliases (CSV)", "Nouveaux alias (CSV)"),
     ),
     refetch: bool = typer.Option(
-        False, "--refetch", "-r", help=tr_multi("Refetch metadata from Wikidata", "Re-fetch metadata from Wikidata", "Re-rechercher les métadonnées Wikidata"),
+        False, "--repreni", "-r", help=tr_multi("Refetch metadata from Wikidata", "Re-fetch metadata from Wikidata", "Re-rechercher les métadonnées Wikidata"),
     ),
     lingvo: Optional[str] = typer.Option(
         None, "-l", "--lingvo", help=tr_multi("Lingvokodoj por refetch (ex: eo,en)", "Language codes for refetch (e.g. eo,en)", "Codes de langue pour refetch (ex: eo,en)"),

--- a/src/A_encik/_cli_special.py
+++ b/src/A_encik/_cli_special.py
@@ -27,7 +27,7 @@ def register_commands(app: typer.Typer) -> None:
         profundeco: int = typer.Option(
             3,
             "-d",
-            "--depth",
+            "--profundo",
             help=tr_multi("Maksimuma profundeco", "Maximum depth", "Profondeur maximale"),
         ),
     ) -> None:
@@ -90,7 +90,7 @@ def register_commands(app: typer.Typer) -> None:
         ),
         revert_newlines: bool = typer.Option(
             False,
-            "--revert-newlines",
+            "--malfari-liniojn",
             hidden=True,
             help=tr_multi(
                 "Malfari difekton de \\n (por retro-ĝisdatigo)",
@@ -158,7 +158,7 @@ def register_commands(app: typer.Typer) -> None:
         ),
         formato: str = typer.Option(
             "enc",
-            "--format",
+            "--formato",
             "-f",
             help=tr_multi("Formato: enc aŭ json", "Format: enc or json", "Format: enc ou json"),
         ),
@@ -271,7 +271,7 @@ def register_commands(app: typer.Typer) -> None:
         ),
         verbose: bool = typer.Option(
             False,
-            "--verbose",
+            "--detala",
             "-v",
             help=tr_multi(
                 "Montri la plenan konversacion kun LLM",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,7 +155,7 @@ class TestAldoniCommand:
     
     def test_aldoni_jaro_bce(self, runner):
         """Test aldoni with --jaro --bce creates BCE year entry."""
-        result = runner.invoke(app, ["aldoni", "--jaro", "44", "--bce"])
+        result = runner.invoke(app, ["aldoni", "--jaro", "44", "--antau-kristo"])
         
         assert result.exit_code == 0
         assert "UUID:" in result.output


### PR DESCRIPTION
P0 option flag renames:\n- --bce -> --antau-kristo\n- --open -> --malfermi\n- --hard -> --permanenta\n- --refetch -> --repreni\n- --revert-newlines -> --malfari-liniojn\n- --verbose -> --detala\n- --depth -> --profundo\n- --format -> --formato\n\nPart of systematic eo locale enforcement across the A-ecosystem.